### PR TITLE
Update Python template Dockerfile to include entrypoint

### DIFF
--- a/dataflow/flex-templates/streaming_beam/Dockerfile
+++ b/dataflow/flex-templates/streaming_beam/Dockerfile
@@ -31,3 +31,5 @@ RUN apt-get update \
 
 # Since we already downloaded all the dependencies, there's no need to rebuild everything.
 ENV PIP_NO_DEPS=True
+
+ENTRYPOINT ["/opt/google/dataflow/python_template_launcher"]


### PR DESCRIPTION
## Description

This has caused some confusion in the past, and is important to make our examples aligned with the instructions here: https://cloud.google.com/dataflow/docs/guides/templates/configuring-flex-templates#use_custom_container_images.

![image](https://github.com/bvolpato/python-docs-samples/assets/3207647/fafa4ff7-3320-4e04-a5fe-ab3f6e05f3a2)
